### PR TITLE
Fix error message and turn it into an exception.

### DIFF
--- a/cyanure.py
+++ b/cyanure.py
@@ -364,9 +364,9 @@ class BinaryClassifier(ERM):
 
         y=np.squeeze(y)
         uniq=np.unique(y)
-        if uniq.shape[0] != 2:
-            print(uniq.shape[0]+" classes detected; use MulticlassClassifier instead")
-            return
+        nb_classes = len(uniq)
+        if nb_classes != 2:
+            raise ValueError("{} classes detected; use MulticlassClassifier instead".format(nb_classes))
         if not np.all(uniq == [-1, 1]):
             print("You have called BinaryClassifier, labels should be either -1 or 1, but they are")
             print(np.unique(y))


### PR DESCRIPTION
Context: I was trying to use cyanure on RCV1 as `sklearn.datasets.fetch_rcv1` returns it:

```py
import numpy as np 
 
from sklearn.datasets import fetch_rcv1 
 
import cyanure as cyan 
 
X, y = fetch_rcv1(return_X_y=True) 
 
#normalize the rows of X in-place, without performing any copy 
cyan.preprocess(X,normalize=True,columns=False) 
#declare a binary classifier for l2-logistic regression 
classifier=cyan.BinaryClassifier(loss='logistic',penalty='l2') 
# uses the auto solver by default, performs at most 500 epochs 
classifier.fit(X,y,lambd=0.1/X.shape[0],max_epochs=500,tol=1e-3,it0=5)                        
```

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
/tmp/test.py in <module>
     13 classifier=cyan.BinaryClassifier(loss='logistic',penalty='l2')
     14 # uses the auto solver by default, performs at most 500 epochs
---> 15 classifier.fit(X,y,lambd=0.1/X.shape[0],max_epochs=500,tol=1e-3,it0=5)

/tmp/cyanure/cyanure.py in fit(self, X, y, lambd, lambd2, lambd3, solver, tol, it0, max_epochs, l_qning, f_restart, verbose, restart, nthreads, seed)
    366         uniq=np.unique(y)
    367         if uniq.shape[0] != 2:
--> 368             print(uniq.shape[0]+" classes detected; use MulticlassClassifier instead")
    369             return
    370         if not np.all(uniq == [-1, 1]):

TypeError: unsupported operand type(s) for +: 'int' and 'str'
```