### PR TITLE
FIX dependency on scipy in setup

### DIFF
--- a/setup_cyanure_mkl.py
+++ b/setup_cyanure_mkl.py
@@ -1,23 +1,27 @@
 from setuptools import setup, Extension
 import numpy
 
-libs = ['mkl_rt','iomp5']
+libs = ['mkl_rt', 'iomp5']
 
-cyanure_wrap=Extension('cyanure_wrap', 
-        libraries = libs,
-        include_dirs=[numpy.get_include()],
-        language='c++',
-        extra_compile_args = ['-DNDEBUG', '-DINT_64BITS', '-DHAVE_MKL', '-DAXPBY', '-fPIC', '-fopenmp', '-std=c++11', '-Wno-unused-function', '-Wno-write-strings' , '-fmax-errors=5'],
-        sources=['cyanure_wrap_module.cpp'])
+
+cyanure_wrap = Extension(
+    'cyanure_wrap',
+    libraries=libs,
+    include_dirs=[numpy.get_include()],
+    language='c++',
+    extra_compile_args=[
+        '-DNDEBUG', '-DINT_64BITS', '-DHAVE_MKL', '-DAXPBY', '-fPIC',
+        '-fopenmp', '-std=c++11', '-Wno-unused-function',
+        '-Wno-write-strings', '-fmax-errors=5'],
+    sources=['cyanure_wrap_module.cpp'])
 
 setup(name='cyanure-mkl',
-        version='0.2',
-        author="Julien Mairal",
-        author_email="julien.mairal@inria.fr",
-        license='bsd-3-clause',
-        url="http://julien.mairal.org/cyanure/",
-        description='optimization toolbox for machine learning',
-        ext_modules=[cyanure_wrap],
-        py_modules=['cyanure'])
-
-
+      version='0.2',
+      author="Julien Mairal",
+      author_email="julien.mairal@inria.fr",
+      license='bsd-3-clause',
+      url="http://julien.mairal.org/cyanure/",
+      description='optimization toolbox for machine learning',
+      install_requires=['scipy'],
+      ext_modules=[cyanure_wrap],
+      py_modules=['cyanure'])

--- a/setup_cyanure_mkl_no_openmp.py
+++ b/setup_cyanure_mkl_no_openmp.py
@@ -1,23 +1,28 @@
 from setuptools import setup, Extension
 import numpy
 
+
 libs = ['mkl_rt']
 
-cyanure_wrap=Extension('cyanure_wrap', 
-        libraries = libs,
+
+cyanure_wrap = Extension(
+        'cyanure_wrap',
+        libraries=libs,
         include_dirs=[numpy.get_include()],
         language='c++',
-        extra_compile_args = ['-DNDEBUG', '-DINT_64BITS', '-DHAVE_MKL', '-DAXPBY', '-fPIC', '-std=c++11', '-Wno-unused-function', '-Wno-write-strings' , '-fmax-errors=5', '-w'],
+        extra_compile_args=[
+                '-DNDEBUG', '-DINT_64BITS', '-DHAVE_MKL', '-DAXPBY', '-fPIC',
+                '-std=c++11', '-Wno-unused-function', '-Wno-write-strings',
+                '-fmax-errors=5', '-w'],
         sources=['cyanure_wrap_module.cpp'])
 
 setup(name='cyanure-mkl-no-openmp',
-        version='0.2',
-        author="Julien Mairal",
-        author_email="julien.mairal@inria.fr",
-        license='bsd-3-clause',
-        url="http://julien.mairal.org/cyanure/",
-        description='optimization toolbox for machine learning',
-        ext_modules=[cyanure_wrap],
-        py_modules=['cyanure'])
-
-
+      version='0.2',
+      author="Julien Mairal",
+      author_email="julien.mairal@inria.fr",
+      license='bsd-3-clause',
+      url="http://julien.mairal.org/cyanure/",
+      description='optimization toolbox for machine learning',
+      install_requires=['scipy'],
+      ext_modules=[cyanure_wrap],
+      py_modules=['cyanure'])

--- a/setup_cyanure_openblas.py
+++ b/setup_cyanure_openblas.py
@@ -1,23 +1,26 @@
 from setuptools import setup, Extension
 import numpy
 
-libs = ['openblas','gomp']
+libs = ['openblas', 'gomp']
 
-cyanure_wrap=Extension('cyanure_wrap', 
-        libraries = libs,
-        include_dirs=[numpy.get_include(), '/usr/local/lib/'],
-        language='c++',
-        extra_compile_args = ['-DNDEBUG', '-DINT_64BITS', '-DAXPBY', '-fPIC', '-fopenmp', '-std=c++11', '-Wno-unused-function', '-Wno-write-strings' , '-fmax-errors=5'],
-        sources=['cyanure_wrap_module.cpp'])
+
+cyanure_wrap = Extension(
+    'cyanure_wrap',
+    libraries=libs,
+    include_dirs=[numpy.get_include(), '/usr/local/lib/'],
+    language='c++',
+    extra_compile_args=[
+        '-DNDEBUG', '-DINT_64BITS', '-DAXPBY', '-fPIC', '-fopenmp',
+        '-std=c++11', '-Wno-unused-function', '-Wno-write-strings',
+        '-fmax-errors=5'],
+    sources=['cyanure_wrap_module.cpp'])
 
 setup(name='cyanure-openblas',
-        version='0.2',
-        author_email="julien.mairal@inria.fr",
-        license='bsd-3-clause',
-        url="http://julien.mairal.org/cyanure/",
-        description='optimization toolbox for machine learning',
-#        install_requires=['openblas'],
-        ext_modules=[cyanure_wrap],
-        py_modules=['cyanure'])
-
-
+      version='0.2',
+      author_email="julien.mairal@inria.fr",
+      license='bsd-3-clause',
+      url="http://julien.mairal.org/cyanure/",
+      description='optimization toolbox for machine learning',
+      install_requires=['scipy'],
+      ext_modules=[cyanure_wrap],
+      py_modules=['cyanure'])

--- a/setup_cyanure_openblas_no_openmp.py
+++ b/setup_cyanure_openblas_no_openmp.py
@@ -3,21 +3,24 @@ import numpy
 
 libs = ['openblas']
 
-cyanure_wrap=Extension('cyanure_wrap', 
-        libraries = libs,
-        include_dirs=[numpy.get_include()],
-        language='c++',
-        extra_compile_args = ['-DNDEBUG', '-DINT_64BITS', '-DAXPBY', '-fPIC', '-std=c++11', '-Wno-unused-function', '-Wno-write-strings' , '-fmax-errors=5', '-w'],
-        sources=['cyanure_wrap_module.cpp'])
+
+cyanure_wrap = Extension(
+    'cyanure_wrap',
+    libraries=libs,
+    include_dirs=[numpy.get_include()],
+    language='c++',
+    extra_compile_args=[
+            '-DNDEBUG', '-DINT_64BITS', '-DAXPBY', '-fPIC', '-std=c++11',
+            '-Wno-unused-function', '-Wno-write-strings', '-fmax-errors=5',
+            '-w'],
+    sources=['cyanure_wrap_module.cpp'])
 
 setup(name='cyanure-openblas-no-openmp',
-        version='0.2',
-        author_email="julien.mairal@inria.fr",
-        license='bsd-3-clause',
-        url="http://julien.mairal.org/cyanure/",
-        description='optimization toolbox for machine learning',
-#        install_requires=['openblas'],
-        ext_modules=[cyanure_wrap],
-        py_modules=['cyanure'])
-
-
+      version='0.2',
+      author_email="julien.mairal@inria.fr",
+      license='bsd-3-clause',
+      url="http://julien.mairal.org/cyanure/",
+      description='optimization toolbox for machine learning',
+      install_requires=['scipy'],
+      ext_modules=[cyanure_wrap],
+      py_modules=['cyanure'])


### PR DESCRIPTION
The `setup.py` script does not include the dependency on `scipy`.
this PR intends to fix this and also reformat the `setup.py` scripts to pep8.

Let me know if you want me to remove the reformatting!