### PR TITLE
Add CI for cyanure - Linux/OpenBLAS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6]
+        use_openmp : ['true', 'false']
+    name: Linux, Python (${{ matrix.python-version }}), OpenBLAS, OpenMP (${{matrix.use_openmp}})
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        pip install numpy
+        sudo apt-get install -y libopenblas-dev
+    - name: Install cyanure
+      run: |
+        if ${{matrix.use_openmp == 'true'}}; then
+          python setup_cyanure_openblas.py install
+        else
+          python setup_cyanure_openblas_no_openmp.py install
+        fi


### PR DESCRIPTION
Closes #11 

In this PR:
We add a CI pipeline using Github Actions.
It specifically validates build for Ubuntu (latest -- specifically 18.04 for now), Python (3.6), OpenBLAS, OpenMP(with/without)
A sample run can be found [here](https://github.com/KranthiGV/cyanure/actions/runs/199464705).

This is currently run each time we push to master or raise a PR to commit to master branch.

It is trickier to get MKL version of numpy installed (without relying on conda during pipeline run). I will work on it after we enable CI for Windows and OSX.